### PR TITLE
fix: Do not filter out journey cancellations

### DIFF
--- a/src/main/java/fi/hsl/transitdata/metroats/MetroEstimatesFactory.java
+++ b/src/main/java/fi/hsl/transitdata/metroats/MetroEstimatesFactory.java
@@ -369,6 +369,13 @@ public class MetroEstimatesFactory {
     }
 
     /**
+     * Check if the estimate is a journey cancellation.
+     */
+    private static boolean isJourneyCancellation(MetroEstimate estimate) {
+        return estimate.journeySectionprogress == MetroProgress.CANCELLED;
+    }
+
+    /**
      * Checks if the metro prediction is considered fairly reliable.
      *
      * We have learned that the Metro Mipro ATS API sends unreliable predictions for a vehicle journey for a few
@@ -390,7 +397,7 @@ public class MetroEstimatesFactory {
     public static Optional<MetroEstimate> parsePayload(final byte[] payload) {
         try {
             MetroEstimate metroEstimate = mapper.readValue(payload, MetroEstimate.class);
-            if (!arePredictionsFairlyReliable(metroEstimate)) {
+            if (!isJourneyCancellation(metroEstimate) && !arePredictionsFairlyReliable(metroEstimate)) {
                 log.debug(
                         "Dropped untrustworthy Mipro ATS predictions that were given before departure from first station. Payload: {}",
                         new String(payload));

--- a/src/test/java/fi.hsl.transitdata.metroats/MetroEstimatesFactoryTest.java
+++ b/src/test/java/fi.hsl.transitdata.metroats/MetroEstimatesFactoryTest.java
@@ -33,7 +33,7 @@ public class MetroEstimatesFactoryTest {
     }
 
     @Test
-    public void testParsePayloadWithNoMeasuredDepartureTimeForFirstStation() throws Exception {
+    public void testDropPayloadWithNoMeasuredDepartureTimeForFirstStation() throws Exception {
         // The API surprisingly uses "null" instead of null in JSON.
         String json = """
                 {
@@ -52,7 +52,7 @@ public class MetroEstimatesFactoryTest {
     }
 
     @Test
-    public void testParsePayloadWithMeasuredDepartureTimeForFirstStation() throws Exception {
+    public void testKeepPayloadWithMeasuredDepartureTimeForFirstStation() throws Exception {
         String json = """
                 {
                   "routeName": "M1",

--- a/src/test/java/fi.hsl.transitdata.metroats/MetroEstimatesFactoryTest.java
+++ b/src/test/java/fi.hsl.transitdata.metroats/MetroEstimatesFactoryTest.java
@@ -67,4 +67,25 @@ public class MetroEstimatesFactoryTest {
         Optional<MetroEstimate> result = MetroEstimatesFactory.parsePayload(json.getBytes());
         assertTrue("Should accept messages with a measured departure time for first station", result.isPresent());
     }
+
+    @Test
+    public void testKeepPayloadThatCancelsJourneyEvenWithNoMeasuredDepartureTimeForFirstStation() throws Exception {
+        // The API surprisingly uses "null" instead of null in JSON.
+        String json = """
+                {
+                  "routeName": "M1",
+                  "beginTime": "2023-01-01T12:01:02.345Z",
+                  "journeySectionprogress": "CANCELLED",
+                  "routeRows": [
+                    {
+                      "station": "KIV",
+                      "departureTimeMeasured": "null"
+                    }
+                  ]
+                }""";
+        Optional<MetroEstimate> result = MetroEstimatesFactory.parsePayload(json.getBytes());
+        assertTrue(
+                "Should accept messages that cancel the whole vehicle journey even if they do not have a measured departure time for first station",
+                result.isPresent());
+    }
 }


### PR DESCRIPTION
Fixes [AB#71261](https://dev.azure.com/hslfi/24efe23f-34ba-4a39-aaad-679208cae463/_workitems/edit/71261)

According to further discussion in the issue, journey cancellations should go through.

- **fix: Do not drop messages that cancel the journey**
- **test: Clarify test names**
