### PR TITLE
Revert early prediction filtering

### DIFF
--- a/src/main/java/fi/hsl/transitdata/metroats/MetroEstimatesFactory.java
+++ b/src/main/java/fi/hsl/transitdata/metroats/MetroEstimatesFactory.java
@@ -368,41 +368,9 @@ public class MetroEstimatesFactory {
         }
     }
 
-    /**
-     * Check if the estimate is a journey cancellation.
-     */
-    private static boolean isJourneyCancellation(MetroEstimate estimate) {
-        return estimate.journeySectionprogress == MetroProgress.CANCELLED;
-    }
-
-    /**
-     * Checks if the metro prediction is considered fairly reliable.
-     *
-     * We have learned that the Metro Mipro ATS API sends unreliable predictions for a vehicle journey for a few
-     * minutes before the departure from the first station. Those faulty predictions tend to predict an early departure
-     * from the first station. That almost never happens as the drivers will wait until the vehicle journey is planned
-     * to start.
-     *
-     * This method filters out predictions where the first station's departureTimeMeasured is missing (or invalid).
-     *
-     * @param estimate the MetroEstimate to validate
-     * @return true if the predictions can be considered fairly reliable or no predictions were given,
-     *         false if the predictions cannot be considered fairly reliable
-     */
-    private static boolean arePredictionsFairlyReliable(MetroEstimate estimate) {
-        return estimate.routeRows == null || estimate.routeRows.isEmpty()
-                || estimate.routeRows.get(0).departureTimeMeasured != null;
-    }
-
     public static Optional<MetroEstimate> parsePayload(final byte[] payload) {
         try {
             MetroEstimate metroEstimate = mapper.readValue(payload, MetroEstimate.class);
-            if (!isJourneyCancellation(metroEstimate) && !arePredictionsFairlyReliable(metroEstimate)) {
-                log.debug(
-                        "Dropped untrustworthy Mipro ATS predictions that were given before departure from first station. Payload: {}",
-                        new String(payload));
-                return Optional.empty();
-            }
             return Optional.of(metroEstimate);
         } catch (Exception e) {
             log.warn("Failed to parse payload {}.", new String(payload), e);

--- a/src/test/java/fi.hsl.transitdata.metroats/MetroEstimatesFactoryTest.java
+++ b/src/test/java/fi.hsl.transitdata.metroats/MetroEstimatesFactoryTest.java
@@ -1,14 +1,15 @@
 package fi.hsl.transitdata.metroats;
 
-import static org.junit.Assert.*;
-
 import fi.hsl.common.files.FileUtils;
 import fi.hsl.transitdata.metroats.models.MetroEstimate;
 import fi.hsl.transitdata.metroats.models.MetroStopEstimate;
+import org.junit.Test;
+
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Optional;
-import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class MetroEstimatesFactoryTest {
 
@@ -30,62 +31,5 @@ public class MetroEstimatesFactoryTest {
         assertEquals("2019-07-09T05:06:30.404Z", metroStopEstimate.departureTimePlanned);
         assertEquals("2019-07-09T05:06:13.941Z", metroStopEstimate.departureTimeForecast);
         assertEquals("2019-07-09T05:06:32.578Z", metroStopEstimate.departureTimeMeasured);
-    }
-
-    @Test
-    public void testDropPayloadWithNoMeasuredDepartureTimeForFirstStation() throws Exception {
-        // The API surprisingly uses "null" instead of null in JSON.
-        String json = """
-                {
-                  "routeName": "M1",
-                  "beginTime": "2023-01-01T12:01:02.345Z",
-                  "routeRows": [
-                    {
-                      "station": "KIV",
-                      "departureTimeMeasured": "null"
-                    }
-                  ]
-                }""";
-        Optional<MetroEstimate> result = MetroEstimatesFactory.parsePayload(json.getBytes());
-        assertFalse("Should filter out messages without a measured departure time for first station",
-                result.isPresent());
-    }
-
-    @Test
-    public void testKeepPayloadWithMeasuredDepartureTimeForFirstStation() throws Exception {
-        String json = """
-                {
-                  "routeName": "M1",
-                  "beginTime": "2023-01-01T12:01:02.345Z",
-                  "routeRows": [
-                    {
-                      "station": "KIV",
-                      "departureTimeMeasured": "2023-01-01T12:01:05.678Z"
-                    }
-                  ]
-                }""";
-        Optional<MetroEstimate> result = MetroEstimatesFactory.parsePayload(json.getBytes());
-        assertTrue("Should accept messages with a measured departure time for first station", result.isPresent());
-    }
-
-    @Test
-    public void testKeepPayloadThatCancelsJourneyEvenWithNoMeasuredDepartureTimeForFirstStation() throws Exception {
-        // The API surprisingly uses "null" instead of null in JSON.
-        String json = """
-                {
-                  "routeName": "M1",
-                  "beginTime": "2023-01-01T12:01:02.345Z",
-                  "journeySectionprogress": "CANCELLED",
-                  "routeRows": [
-                    {
-                      "station": "KIV",
-                      "departureTimeMeasured": "null"
-                    }
-                  ]
-                }""";
-        Optional<MetroEstimate> result = MetroEstimatesFactory.parsePayload(json.getBytes());
-        assertTrue(
-                "Should accept messages that cancel the whole vehicle journey even if they do not have a measured departure time for first station",
-                result.isPresent());
     }
 }


### PR DESCRIPTION
Mipro Metro ATS has stopped producing early forecasts. We wish to see
what the effects look like as such.

Fixes [AB#76710](https://dev.azure.com/hslfi/03abb832-d69d-4745-8e0f-e045519e6411/_workitems/edit/76710)
